### PR TITLE
Fixing typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ lib.update("books",
 		}
 	},
 	function(row) { // update function
-		row.year+=5;
+		row.copies+=5;
 		return row;
 	}
 );


### PR DESCRIPTION
According to your comment, if a book is published after 2003, you want to add 5 copies, but in your example, you are adding 5 years to its publish date. Very minor, but noticeable typo.
