### PR TITLE
Removal of unnecessary loop

### DIFF
--- a/localstoragedb.js
+++ b/localstoragedb.js
@@ -603,12 +603,10 @@
 					return insert(table_name, validateData(table_name, data) );
 				} else {
 					var ids = [];
-					for(var n=0; n<result_ids.length; n++) {
-						update(table_name, result_ids, function(o) {
-							ids.push(o.ID);
-							return data;
-						});
-					}
+					update(table_name, result_ids, function(o) {
+						ids.push(o.ID);
+						return data;
+					});
 
 					return ids;
 				}


### PR DESCRIPTION
The function `update` already loops through `result_ids`.

For N ids in `result_ids`, it would execute N^2 times!

It doesn't happen anymore and improved a LOT of time mainly for major lists.