### PR TITLE
Fix bug empty table

### DIFF
--- a/sample/main.js
+++ b/sample/main.js
@@ -38,7 +38,6 @@ $(document).ready(function(){
 
     $('#btnInsert').click(function(){
 
-        $(':input').val('');
         
         if (! db.tableExists(tableName) )
         {
@@ -67,6 +66,7 @@ $(document).ready(function(){
             vCopies + '</td><td><a href="#" onclick="rowDelete(this); return false;">Delete</a></td></tr>';
 
         $("#tblContent tbody").append(newRowContent);
+        $(':input').val('');
 
     });
 


### PR DESCRIPTION
$(':input').val('') runs before the table insert, and it insert empty values. It should be at the end of the method.