### PR TITLE
Replace obsolete yarn command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ the structured data is stored as serialized JSON in localStorage or sessionStora
 `npm install localstoragedb`
 
 ## Yarn
-`yarn install localstoragedb`
+`yarn add localstoragedb`
 
 ## Bower
 `bower install localstoragedb`


### PR DESCRIPTION
`install` has been replaced with `add` to add new dependencies.